### PR TITLE
Checking for existing NRQL Alert conditions

### DIFF
--- a/controllers/nrqlalertcondition_controller.go
+++ b/controllers/nrqlalertcondition_controller.go
@@ -55,28 +55,10 @@ func (r *NrqlAlertConditionReconciler) Reconcile(req ctrl.Request) (ctrl.Result,
 		return ctrl.Result{}, nil
 	}
 
-
 	r.Log.Info("Reconciling", "condition", condition)
 
 	//check if condition has condition id
-	if condition.Status.ConditionID == 0 {
-		r.Log.Info("Checking for existing condition", "conditionName", condition.Name)
-		//if no conditionId, get list of conditions and compare name
-		existingConditions, err := r.Alerts.ListNrqlConditions(condition.Spec.ExistingPolicyId)
-		r.Log.Info("existingConditions", "existingConditions", existingConditions)
-		if err != nil {
-			r.Log.Error(err, "failed to get list of NRQL conditions from New Relic API")
-		} else {
-			for _, existingCondition := range *existingConditions {
-				if existingCondition.Name == condition.Spec.Name {
-					r.Log.Info("Matched on existing condition, updating ConditionId", "conditionId", existingCondition.ID)
-					condition.Status.ConditionID = existingCondition.ID
-				}
-				break
-			}
-		}
-
-	}
+	r.checkForExistingCondition(&condition)
 
 	APICondition := condition.Spec.APICondition()
 	r.Log.Info("Trying to create or update condition", "API fields", APICondition)
@@ -112,6 +94,27 @@ func (r *NrqlAlertConditionReconciler) Reconcile(req ctrl.Request) (ctrl.Result,
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *NrqlAlertConditionReconciler) checkForExistingCondition(condition *nralertsv1beta1.NrqlAlertCondition) {
+	if condition.Status.ConditionID == 0 {
+		r.Log.Info("Checking for existing condition", "conditionName", condition.Name)
+		//if no conditionId, get list of conditions and compare name
+		existingConditions, err := r.Alerts.ListNrqlConditions(condition.Spec.ExistingPolicyId)
+		r.Log.Info("existingConditions", "existingConditions", existingConditions)
+		if err != nil {
+			r.Log.Error(err, "failed to get list of NRQL conditions from New Relic API")
+		} else {
+			for _, existingCondition := range existingConditions {
+				if existingCondition.Name == condition.Spec.Name {
+					r.Log.Info("Matched on existing condition, updating ConditionId", "conditionId", existingCondition.ID)
+					condition.Status.ConditionID = existingCondition.ID
+				}
+				break
+			}
+		}
+
+	}
 }
 
 func (r *NrqlAlertConditionReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/nrqlalertcondition_controller_test.go
+++ b/controllers/nrqlalertcondition_controller_test.go
@@ -122,13 +122,13 @@ var _ = Describe("NrqlCondition reconciliation", func() {
 			a.ID = 112
 			return &a, nil
 		}
-		alertsClient.ListNrqlConditionsStub = func(int) (*[]alerts.NrqlCondition, error) {
-			var a []alerts.NrqlCondition
-			a = append(a, alerts.NrqlCondition{
-				ID: 112,
+		alertsClient.ListNrqlConditionsStub = func(int) ([]*alerts.NrqlCondition, error) {
+			var a []*alerts.NrqlCondition
+			a = append(a, &alerts.NrqlCondition{
+				ID:   112,
 				Name: "NRQL Condition matches",
 			})
-			return &a, nil
+			return a, nil
 		}
 	})
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -54,6 +54,7 @@ var _ = BeforeSuite(func(done Done) {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
 	}
+	// Uncomment to get verbose logs in your tests
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 
 	var err error

--- a/interfaces/interfacesfakes/fake_new_relic_alerts_client.go
+++ b/interfaces/interfacesfakes/fake_new_relic_alerts_client.go
@@ -22,17 +22,17 @@ type FakeNewRelicAlertsClient struct {
 		result1 *alerts.NrqlCondition
 		result2 error
 	}
-	ListNrqlConditionsStub        func(int) (*[]alerts.NrqlCondition, error)
+	ListNrqlConditionsStub        func(int) ([]*alerts.NrqlCondition, error)
 	listNrqlConditionsMutex       sync.RWMutex
 	listNrqlConditionsArgsForCall []struct {
 		arg1 int
 	}
 	listNrqlConditionsReturns struct {
-		result1 *[]alerts.NrqlCondition
+		result1 []*alerts.NrqlCondition
 		result2 error
 	}
 	listNrqlConditionsReturnsOnCall map[int]struct {
-		result1 *[]alerts.NrqlCondition
+		result1 []*alerts.NrqlCondition
 		result2 error
 	}
 	UpdateNrqlConditionStub        func(alerts.NrqlCondition) (*alerts.NrqlCondition, error)
@@ -115,7 +115,7 @@ func (fake *FakeNewRelicAlertsClient) CreateNrqlConditionReturnsOnCall(i int, re
 	}{result1, result2}
 }
 
-func (fake *FakeNewRelicAlertsClient) ListNrqlConditions(arg1 int) (*[]alerts.NrqlCondition, error) {
+func (fake *FakeNewRelicAlertsClient) ListNrqlConditions(arg1 int) ([]*alerts.NrqlCondition, error) {
 	fake.listNrqlConditionsMutex.Lock()
 	ret, specificReturn := fake.listNrqlConditionsReturnsOnCall[len(fake.listNrqlConditionsArgsForCall)]
 	fake.listNrqlConditionsArgsForCall = append(fake.listNrqlConditionsArgsForCall, struct {
@@ -139,7 +139,7 @@ func (fake *FakeNewRelicAlertsClient) ListNrqlConditionsCallCount() int {
 	return len(fake.listNrqlConditionsArgsForCall)
 }
 
-func (fake *FakeNewRelicAlertsClient) ListNrqlConditionsCalls(stub func(int) (*[]alerts.NrqlCondition, error)) {
+func (fake *FakeNewRelicAlertsClient) ListNrqlConditionsCalls(stub func(int) ([]*alerts.NrqlCondition, error)) {
 	fake.listNrqlConditionsMutex.Lock()
 	defer fake.listNrqlConditionsMutex.Unlock()
 	fake.ListNrqlConditionsStub = stub
@@ -152,28 +152,28 @@ func (fake *FakeNewRelicAlertsClient) ListNrqlConditionsArgsForCall(i int) int {
 	return argsForCall.arg1
 }
 
-func (fake *FakeNewRelicAlertsClient) ListNrqlConditionsReturns(result1 *[]alerts.NrqlCondition, result2 error) {
+func (fake *FakeNewRelicAlertsClient) ListNrqlConditionsReturns(result1 []*alerts.NrqlCondition, result2 error) {
 	fake.listNrqlConditionsMutex.Lock()
 	defer fake.listNrqlConditionsMutex.Unlock()
 	fake.ListNrqlConditionsStub = nil
 	fake.listNrqlConditionsReturns = struct {
-		result1 *[]alerts.NrqlCondition
+		result1 []*alerts.NrqlCondition
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeNewRelicAlertsClient) ListNrqlConditionsReturnsOnCall(i int, result1 *[]alerts.NrqlCondition, result2 error) {
+func (fake *FakeNewRelicAlertsClient) ListNrqlConditionsReturnsOnCall(i int, result1 []*alerts.NrqlCondition, result2 error) {
 	fake.listNrqlConditionsMutex.Lock()
 	defer fake.listNrqlConditionsMutex.Unlock()
 	fake.ListNrqlConditionsStub = nil
 	if fake.listNrqlConditionsReturnsOnCall == nil {
 		fake.listNrqlConditionsReturnsOnCall = make(map[int]struct {
-			result1 *[]alerts.NrqlCondition
+			result1 []*alerts.NrqlCondition
 			result2 error
 		})
 	}
 	fake.listNrqlConditionsReturnsOnCall[i] = struct {
-		result1 *[]alerts.NrqlCondition
+		result1 []*alerts.NrqlCondition
 		result2 error
 	}{result1, result2}
 }

--- a/interfaces/new_relic_alert_client.go
+++ b/interfaces/new_relic_alert_client.go
@@ -6,5 +6,5 @@ import "github.com/newrelic/newrelic-client-go/pkg/alerts"
 type NewRelicAlertsClient interface {
 	CreateNrqlCondition(alerts.NrqlCondition) (*alerts.NrqlCondition, error)
 	UpdateNrqlCondition(alerts.NrqlCondition) (*alerts.NrqlCondition, error)
-	ListNrqlConditions(int) (*[]alerts.NrqlCondition, error)
+	ListNrqlConditions(int) ([]*alerts.NrqlCondition, error)
 }


### PR DESCRIPTION
This adds capability to the Kubernetes Alert operator to check for the existence of New Relic NRQL Alert conditions in the existingPolicyId by matching based on the Name of the New Relic Alert Condition. If existing conditions are found, they will be updated to match the CRD.