### PR TITLE
refactor(k8api): Refactored k8 API Group from nr-alerts to nr

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,7 +1,7 @@
 domain: k8s.newrelic.com
 repo: github.com/newrelic/newrelic-kubernetes-operator
 resources:
-- group: nr-alerts
+- group: nr
   kind: NrqlAlertCondition
   version: v1beta1
 version: "2"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ diff -u resources-before.txt resources-installed.txt
  ingresses                         ing          networking.k8s.io              true         Ingress
  networkpolicies                   netpol       networking.k8s.io              true         NetworkPolicy
  runtimeclasses                                 node.k8s.io                    false        RuntimeClass
-+nrqlalertconditions                            nr-alerts.k8s.newrelic.com     true         NrqlAlertCondition
++nrqlalertconditions                            nr.k8s.newrelic.com     true         NrqlAlertCondition
  poddisruptionbudgets              pdb          policy                         true         PodDisruptionBudget
  podsecuritypolicies               psp          policy                         false        PodSecurityPolicy
  clusterrolebindings                            rbac.authorization.k8s.io      false        ClusterRoleBinding
@@ -83,7 +83,7 @@ The operator will create and update conditions as needed by applying yaml files 
 
 Sample yaml file
 ```
-apiVersion: nr-alerts.k8s.newrelic.com/v1
+apiVersion: nr.k8s.newrelic.com/v1
 kind: NrqlAlertCondition
 metadata:
   name: my-alert
@@ -133,7 +133,7 @@ $ diff -u resources-installed.txt resources-uninstalled.txt
  ingresses                         ing          networking.k8s.io              true         Ingress
  networkpolicies                   netpol       networking.k8s.io              true         NetworkPolicy
  runtimeclasses                                 node.k8s.io                    false        RuntimeClass
--nrqlalertconditions                            nr-alerts.k8s.newrelic.com     true         NrqlAlertCondition
+-nrqlalertconditions                            nr.k8s.newrelic.com     true         NrqlAlertCondition
  poddisruptionbudgets              pdb          policy                         true         PodDisruptionBudget
  podsecuritypolicies               psp          policy                         false        PodSecurityPolicy
  clusterrolebindings                            rbac.authorization.k8s.io      false        ClusterRoleBinding

--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -15,7 +15,7 @@ limitations under the License.
 
 // Package v1 contains API Schema definitions for the nralerts v1 API group
 // +kubebuilder:object:generate=true
-// +groupName=nr-alerts.k8s.newrelic.com
+// +groupName=nr.k8s.newrelic.com
 package v1
 
 import (
@@ -25,7 +25,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "nr-alerts.k8s.newrelic.com", Version: "v1"}
+	GroupVersion = schema.GroupVersion{Group: "nr.k8s.newrelic.com", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1/nrqlalertcondition_webhook.go
+++ b/api/v1/nrqlalertcondition_webhook.go
@@ -50,7 +50,7 @@ func (r *NrqlAlertCondition) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-nr-alerts-k8s-newrelic-com-v1-nrqlalertcondition,mutating=true,failurePolicy=fail,groups=nr-alerts.k8s.newrelic.com,resources=nrqlalertconditions,verbs=create;update,versions=v1,name=mnrqlalertcondition.kb.io
+// +kubebuilder:webhook:path=/mutate-nr-k8s-newrelic-com-v1-nrqlalertcondition,mutating=true,failurePolicy=fail,groups=nr.k8s.newrelic.com,resources=nrqlalertconditions,verbs=create;update,versions=v1,name=mnrqlalertcondition.kb.io
 
 var _ webhook.Defaulter = &NrqlAlertCondition{}
 
@@ -66,7 +66,7 @@ func (r *NrqlAlertCondition) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-nr-alerts-k8s-newrelic-com-v1-nrqlalertcondition,mutating=false,failurePolicy=fail,groups=nr-alerts.k8s.newrelic.com,resources=nrqlalertconditions,versions=v1,name=vnrqlalertcondition.kb.io
+// +kubebuilder:webhook:verbs=create;update,path=/validate-nr-k8s-newrelic-com-v1-nrqlalertcondition,mutating=false,failurePolicy=fail,groups=nr.k8s.newrelic.com,resources=nrqlalertconditions,versions=v1,name=vnrqlalertcondition.kb.io
 
 var _ webhook.Validator = &NrqlAlertCondition{}
 

--- a/config/crd/bases/nr.k8s.newrelic.com_nrqlalertconditions.yaml
+++ b/config/crd/bases/nr.k8s.newrelic.com_nrqlalertconditions.yaml
@@ -6,13 +6,13 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.8
   creationTimestamp: null
-  name: nrqlalertconditions.nr-alerts.k8s.newrelic.com
+  name: nrqlalertconditions.nr.k8s.newrelic.com
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.created
     name: Created
     type: boolean
-  group: nr-alerts.k8s.newrelic.com
+  group: nr.k8s.newrelic.com
   names:
     kind: NrqlAlertCondition
     listKind: NrqlAlertConditionList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/nr-alerts.k8s.newrelic.com_nrqlalertconditions.yaml
+- bases/nr.k8s.newrelic.com_nrqlalertconditions.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/crd/patches/cainjection_in_nrqlalertconditions.yaml
+++ b/config/crd/patches/cainjection_in_nrqlalertconditions.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: nrqlalertconditions.nr-alerts.k8s.newrelic.com
+  name: nrqlalertconditions.nr.k8s.newrelic.com

--- a/config/crd/patches/webhook_in_nrqlalertconditions.yaml
+++ b/config/crd/patches/webhook_in_nrqlalertconditions.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: nrqlalertconditions.nr-alerts.k8s.newrelic.com
+  name: nrqlalertconditions.nr.k8s.newrelic.com
 spec:
   conversion:
     strategy: Webhook

--- a/config/rbac/nrqlalertcondition_editor_role.yaml
+++ b/config/rbac/nrqlalertcondition_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nrqlalertcondition-editor-role
 rules:
 - apiGroups:
-  - nr-alerts.k8s.newrelic.com
+  - nr.k8s.newrelic.com
   resources:
   - nrqlalertconditions
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - nr-alerts.k8s.newrelic.com
+  - nr.k8s.newrelic.com
   resources:
   - nrqlalertconditions/status
   verbs:

--- a/config/rbac/nrqlalertcondition_viewer_role.yaml
+++ b/config/rbac/nrqlalertcondition_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nrqlalertcondition-viewer-role
 rules:
 - apiGroups:
-  - nr-alerts.k8s.newrelic.com
+  - nr.k8s.newrelic.com
   resources:
   - nrqlalertconditions
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - nr-alerts.k8s.newrelic.com
+  - nr.k8s.newrelic.com
   resources:
   - nrqlalertconditions/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - nr-alerts.k8s.newrelic.com
+  - nr.k8s.newrelic.com
   resources:
   - nrqlalertconditions
   verbs:
@@ -19,7 +19,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - nr-alerts.k8s.newrelic.com
+  - nr.k8s.newrelic.com
   resources:
   - nrqlalertconditions/status
   verbs:

--- a/config/samples/nr-alerts_v1_nrqlalertcondition.yaml
+++ b/config/samples/nr-alerts_v1_nrqlalertcondition.yaml
@@ -1,4 +1,4 @@
-apiVersion: nr-alerts.k8s.newrelic.com/v1
+apiVersion: nr.k8s.newrelic.com/v1
 kind: NrqlAlertCondition
 metadata:
   name: nrqlalertcondition-sample

--- a/config/samples/nr-alerts_v1beta1_nrqlalertcondition.yaml
+++ b/config/samples/nr-alerts_v1beta1_nrqlalertcondition.yaml
@@ -1,4 +1,4 @@
-apiVersion: nr-alerts.k8s.newrelic.com/v1beta1
+apiVersion: nr.k8s.newrelic.com/v1beta1
 kind: NrqlAlertCondition
 metadata:
   name: nrqlalertcondition-sample

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -11,12 +11,12 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-nr-alerts-k8s-newrelic-com-v1-nrqlalertcondition
+      path: /mutate-nr-k8s-newrelic-com-v1-nrqlalertcondition
   failurePolicy: Fail
   name: mnrqlalertcondition.kb.io
   rules:
   - apiGroups:
-    - nr-alerts.k8s.newrelic.com
+    - nr.k8s.newrelic.com
     apiVersions:
     - v1
     operations:
@@ -37,12 +37,12 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-nr-alerts-k8s-newrelic-com-v1-nrqlalertcondition
+      path: /validate-nr-k8s-newrelic-com-v1-nrqlalertcondition
   failurePolicy: Fail
   name: vnrqlalertcondition.kb.io
   rules:
   - apiGroups:
-    - nr-alerts.k8s.newrelic.com
+    - nr.k8s.newrelic.com
     apiVersions:
     - v1
     operations:

--- a/controllers/nrqlalertcondition_controller.go
+++ b/controllers/nrqlalertcondition_controller.go
@@ -43,8 +43,8 @@ type NrqlAlertConditionReconciler struct {
 	AlertClientFunc func(string, string) (interfaces.NewRelicAlertsClient, error)
 }
 
-// +kubebuilder:rbac:groups=nr-alerts.k8s.newrelic.com,resources=nrqlalertconditions,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=nr-alerts.k8s.newrelic.com,resources=nrqlalertconditions/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=nr.k8s.newrelic.com,resources=nrqlalertconditions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=nr.k8s.newrelic.com,resources=nrqlalertconditions/status,verbs=get;update;patch
 
 func (r *NrqlAlertConditionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()

--- a/example.yaml
+++ b/example.yaml
@@ -1,4 +1,4 @@
-apiVersion: nr-alerts.k8s.newrelic.com/v1
+apiVersion: nr.k8s.newrelic.com/v1
 kind: NrqlAlertCondition
 metadata:
   name: alert-1029266


### PR DESCRIPTION
Renames the k8 API Group from nr-alerts to nr to set us up for adding resources outside the nr-alerts space