### PR TITLE
tests(api): Add test showing the webhook ValidateCreate fail

### DIFF
--- a/api/v1/nrqlalertcondition_webhook_test.go
+++ b/api/v1/nrqlalertcondition_webhook_test.go
@@ -149,4 +149,16 @@ var _ = Describe("ValidateCreate", func() {
 		})
 
 	})
+
+	Describe("InvalidPolicyID", func() {
+		Context("With a Policy ID that does not exist", func() {
+			BeforeEach(func() {
+				r.Spec.ExistingPolicyID = 0
+			})
+			It("returns an error", func() {
+				err := r.ValidateCreate()
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
 })


### PR DESCRIPTION
Small test for completeness of ValidateCreate, when the ExistingPolicyID does not exist. Ensures the error is thrown.