### PR TITLE
docs(build): update target url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/relea
 Install the operator in the test cluster.
 
 ``` bash
-kustomize build https://newrelic.github.io/newrelic-kubernetes-operator/config/default/ \
+kustomize build https://github.com/newrelic/newrelic-kubernetes-operator/config/default \
   | kubectl apply -f -
 ```
 


### PR DESCRIPTION
updates the URL to something that will work directly from github for those not wanting to clone the repo