### PR TITLE
docs(build): Correct url for kustomize build in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/relea
 Install the operator in the test cluster.
 
 ``` bash
-kustomize build https://newrelic.github.io/newrelic-kubernetes-operator/config/default/ \
+kustomize build github.com/newrelic/newrelic-kubernetes-operator/config/default/ \
   | kubectl apply -f -
 ```
 


### PR DESCRIPTION
This is the trick that works for a quick start.