### PR TITLE
fix(build): Fix manifest generation with renamed configs dir

### DIFF
--- a/build/kube.mk
+++ b/build/kube.mk
@@ -28,5 +28,5 @@ deploy: manifests docker-build
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: tools
 	@echo "=== $(PROJECT_NAME) === [ manifests        ]: Generating manifests..."
-	@$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=$(RBAC_ROLE_NAME) webhook paths="./..." output:crd:artifacts:config=$(CONFIG_ROOT)/crd/bases
+	@$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=$(RBAC_ROLE_NAME) webhook output:dir=$(CONFIG_ROOT) paths="./..." output:crd:artifacts:config=$(CONFIG_ROOT)/crd/bases
 


### PR DESCRIPTION
Generating manifests (and thus `make install`) was broken in #33 This resolves that by passing the configs dir to `controller-gen` explicitly.