### PR TITLE
Push snapshot docker image on all merges to master

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,30 @@
+name: Snapshot
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Add GOBIN to PATH
+      run: echo "::add-path::$(go env GOPATH)/bin"
+      shell: bash
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Publish Snapshot to Docker
+      shell: bash
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        DOCKER_IMAGE: newrelic/k8s-operator:snapshot
+      run: make docker-push
+


### PR DESCRIPTION
Github action to build/push `snapshot` docker image to docker hub on all master merges.