### PR TITLE
fix(config): increase memory for operator

### DIFF
--- a/configs/manager/manager.yaml
+++ b/configs/manager/manager.yaml
@@ -32,8 +32,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
When we deployed the operator to a test cluster we found it crashed immediately when we attempted to `kubectl apply -f ...` with the example policy.

It didn't take much extra memory to get it working.