### PR TITLE
bug: update rbac permissions

### DIFF
--- a/configs/rbac/role.yaml
+++ b/configs/rbac/role.yaml
@@ -5,6 +5,9 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: manager-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - apiGroups:
   - nr.k8s.newrelic.com


### PR DESCRIPTION
updates rbac permissions to add the built in k8 operator roles access to manage our CRDs