### PR TITLE
chore: refactor createOrUpdateConditions into two smaller methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,19 +9,15 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-logr/logr v0.1.0
-	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
-	github.com/google/go-cmp v0.3.1 // indirect
-	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.3 // indirect
 	github.com/newrelic/newrelic-client-go v0.23.2
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.10.0
-	github.com/psampaz/go-mod-outdated v0.6.0 // indirect
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/tools v0.0.0-20200511202723-1762287ae9dd
 	k8s.io/api v0.17.5
 	k8s.io/apimachinery v0.17.5
 	k8s.io/client-go v0.17.5
 	sigs.k8s.io/controller-runtime v0.4.0
 	sigs.k8s.io/controller-tools v0.2.8
-	github.com/stretchr/testify v1.5.1
 )


### PR DESCRIPTION
This PR contains a small refactoring to reduce the size of the `createOrUpdateConditions` method in `policy_controller.go`.