### PR TITLE
fix(nrqlcondition): more granular thresholds

### DIFF
--- a/api/v1/nrqlalertcondition_types_integration_test.go
+++ b/api/v1/nrqlalertcondition_types_integration_test.go
@@ -23,7 +23,7 @@ var _ = Describe("NrqlAlertConditionSpec", func() {
 					Duration:     resource.MustParse("30"),
 					Operator:     "above",
 					Priority:     "critical",
-					Threshold:    resource.MustParse("5"),
+					Threshold:    resource.MustParse("0.5"),
 					TimeFunction: "all",
 				},
 			},
@@ -46,7 +46,8 @@ var _ = Describe("NrqlAlertConditionSpec", func() {
 
 	Describe("APICondition", func() {
 		It("converts NrqlAlertConditionSpec object to NrqlCondition object from go client, retaining field values", func() {
-			apiCondition := condition.APICondition()
+			apiCondition, err := condition.APICondition()
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(fmt.Sprint(reflect.TypeOf(apiCondition))).To(Equal("alerts.NrqlCondition"))
 
@@ -68,7 +69,7 @@ var _ = Describe("NrqlAlertConditionSpec", func() {
 			Expect(apiTerm.Duration).To(Equal(30))
 			Expect(apiTerm.Operator).To(Equal(alerts.OperatorTypes.Above))
 			Expect(apiTerm.Priority).To(Equal(alerts.PriorityTypes.Critical))
-			Expect(apiTerm.Threshold).To(Equal(float64(5)))
+			Expect(apiTerm.Threshold).To(Equal(float64(0.5)))
 			Expect(apiTerm.TimeFunction).To(Equal(alerts.TimeFunctionTypes.All))
 
 			apiQuery := apiCondition.Nrql

--- a/api/v1/nrqlalertcondition_types_test.go
+++ b/api/v1/nrqlalertcondition_types_test.go
@@ -23,7 +23,7 @@ var _ = Describe("NrqlAlertConditionSpec", func() {
 					Duration:     resource.MustParse("30"),
 					Operator:     "above",
 					Priority:     "critical",
-					Threshold:    resource.MustParse("5"),
+					Threshold:    resource.MustParse("0.5"),
 					TimeFunction: "all",
 				},
 			},
@@ -46,7 +46,8 @@ var _ = Describe("NrqlAlertConditionSpec", func() {
 
 	Describe("APICondition", func() {
 		It("converts NrqlAlertConditionSpec object to NrqlCondition object from go client, retaining field values", func() {
-			apiCondition := condition.APICondition()
+			apiCondition, err := condition.APICondition()
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(fmt.Sprint(reflect.TypeOf(apiCondition))).To(Equal("alerts.NrqlCondition"))
 
@@ -68,7 +69,7 @@ var _ = Describe("NrqlAlertConditionSpec", func() {
 			Expect(apiTerm.Duration).To(Equal(30))
 			Expect(apiTerm.Operator).To(Equal(alerts.OperatorTypes.Above))
 			Expect(apiTerm.Priority).To(Equal(alerts.PriorityTypes.Critical))
-			Expect(apiTerm.Threshold).To(Equal(float64(5)))
+			Expect(apiTerm.Threshold).To(Equal(float64(0.5)))
 			Expect(apiTerm.TimeFunction).To(Equal(alerts.TimeFunctionTypes.All))
 
 			apiQuery := apiCondition.Nrql

--- a/controllers/nrqlalertcondition_controller.go
+++ b/controllers/nrqlalertcondition_controller.go
@@ -147,7 +147,10 @@ func (r *NrqlAlertConditionReconciler) Reconcile(req ctrl.Request) (ctrl.Result,
 	//check if condition has condition id
 	r.checkForExistingCondition(&condition)
 
-	APICondition := condition.Spec.APICondition()
+	APICondition, err := condition.Spec.APICondition()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	if condition.Status.ConditionID != 0 && !reflect.DeepEqual(&condition.Spec, condition.Status.AppliedSpec) {
 		r.Log.Info("updating condition", "ConditionName", condition.Name, "API fields", APICondition)


### PR DESCRIPTION
Presently, trying to use a non-integer threshold produces an error in
serializing the API condition, leading to the cryptic log message:

> ERROR controllers.NrqlAlertCondition failed to update condition {"error": "422 response returned: Query can't be blank. Since value must be an integer. Terms must include at least one critical priority term. Terms operator must be one of the following: above, below, equal. Terms priority must be either warning or critical. Terms time function must be one of the following: any, all. Terms duration must be an integer between 1 and 120 (in minutes). Name can't be blank."}

This happens because the resource gets serialized to JSON as a string
with a scale suffix, e.g. "0.5" becomes "500m" (for 500 milli-units).
That doesn't deserialize into a `float64`, as the Go encoder doesn't
know how to parse that format of string.

This change converts the resource.Quantity type into the less-specific
float64 and integer types used by the API types outside of that JSON
encoding flow.