### PR TITLE
chore: update refs of "k8s-operator" to "kubernetes-operator"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 [![CLA assistant](https://cla-assistant.io/readme/badge/newrelic/newrelic-kubernetes-operator)](https://cla-assistant.io/newrelic/newrelic-kubernetes-operator)
 [![Release](https://img.shields.io/github/release/newrelic/newrelic-kubernetes-operator/all.svg)](https://github.com/newrelic/newrelic-kubernetes-operator/releases/latest)
 
-[![Docker Stars](https://img.shields.io/docker/stars/newrelic/k8s-operator.svg)](https://hub.docker.com/r/newrelic/k8s-operator)
-[![Docker Pulls](https://img.shields.io/docker/pulls/newrelic/k8s-operator.svg)](https://hub.docker.com/r/newrelic/k8s-operator)
-[![Docker Size](https://img.shields.io/docker/image-size/newrelic/k8s-operator.svg?sort=semver)](https://hub.docker.com/r/newrelic/k8s-operator)
-[![Docker Version](https://img.shields.io/docker/v/newrelic/k8s-operator.svg?sort=semver)](https://hub.docker.com/r/newrelic/k8s-operator)
+[![Docker Stars](https://img.shields.io/docker/stars/newrelic/kubernetes-operator.svg)](https://hub.docker.com/r/newrelic/kubernetes-operator)
+[![Docker Pulls](https://img.shields.io/docker/pulls/newrelic/kubernetes-operator.svg)](https://hub.docker.com/r/newrelic/kubernetes-operator)
+[![Docker Size](https://img.shields.io/docker/image-size/newrelic/kubernetes-operator.svg?sort=semver)](https://hub.docker.com/r/newrelic/kubernetes-operator)
+[![Docker Version](https://img.shields.io/docker/v/newrelic/kubernetes-operator.svg?sort=semver)](https://hub.docker.com/r/newrelic/kubernetes-operator)
 
 - [Overview](#overview)
 - [Quick Start](#quick-start)
@@ -82,7 +82,7 @@ If you want to deploy the operator in a custom container you can override the im
    resources:
      - github.com/newrelic/newrelic-kubernetes-operator/configs/default
    images:
-     - name: newrelic/k8s-operator:snapshot
+     - name: newrelic/kubernetes-operator:snapshot
        newName: <CUSTOM_IMAGE>
        newTag: <CUSTOM_TAG>
    ```

--- a/build/docker.mk
+++ b/build/docker.mk
@@ -3,7 +3,7 @@
 #
 DOCKER            ?= docker
 DOCKER_FILE       ?= build/package/Dockerfile
-DOCKER_IMAGE      ?= newrelic/k8s-operator
+DOCKER_IMAGE      ?= newrelic/kubernetes-operator
 DOCKER_IMAGE_TAG  ?= snapshot
 
 # Build the docker image

--- a/build/kube.mk
+++ b/build/kube.mk
@@ -3,7 +3,7 @@
 #
 
 # Image URL to use all building/pushing image targets
-DOCKER_IMAGE   ?= newrelic/k8s-operator:snapshot
+DOCKER_IMAGE   ?= newrelic/kubernetes-operator:snapshot
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS    ?= "crd:trivialVersions=true"
 CONFIG_ROOT    ?= $(SRCDIR)/configs

--- a/configs/manager/kustomization.yaml
+++ b/configs/manager/kustomization.yaml
@@ -4,4 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: newrelic/k8s-operator
+  newName: newrelic/kubernetes-operator


### PR DESCRIPTION
In light of updating the Docker Hub name to be `newrelic/kubernetes-operator`, we need to update some additional refs to the old name `newrelic/k8s-operator`.