### PR TITLE
fix: set LeaderElectionID

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -67,6 +67,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "newrelic-kubernetes-operator",
 		Port:               9443,
 	}
 


### PR DESCRIPTION
Seems to be required with the current version of controller-runtime. 