### PR TITLE
chore(build): Force Github to fetch all history for linting, reset date

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Cache deps
       uses: actions/cache@v1

--- a/build/lint.mk
+++ b/build/lint.mk
@@ -9,7 +9,7 @@ GOIMPORTS    ?= goimports
 
 COMMIT_LINT_CMD   ?= go-gitlint
 COMMIT_LINT_REGEX ?= "(bug|chore|docs|feat|fix|refactor|tests?)(\([^\)]+\))?: .*"
-COMMIT_LINT_START ?= "2020-04-09"
+COMMIT_LINT_START ?= "2020-06-05"
 
 GOLINTER      = golangci-lint
 


### PR DESCRIPTION
Github was not linting commit messages correctly as it does a shallow checkout by default.