### PR TITLE
refactor(build): adjusts build system for main.go in project root

### DIFF
--- a/build/compile.mk
+++ b/build/compile.mk
@@ -10,13 +10,10 @@ PROJECT_MODULE ?= $(shell $(GO) list -m)
 LDFLAGS    ?= "-s -w -X $(PROJECT_NAME)/internal/info.Name=$(PROJECT_NAME) -X $(PROJECT_MODULE)/internal/info.Version=$(PROJECT_VER)"
 SRCDIR     ?= .
 COMPILE_OS ?= darwin linux windows
+BINARYNAME ?= manager
 
 # Determine commands by looking into cmd/*
 COMMANDS   ?= $(wildcard ${SRCDIR}/cmd/*)
-
-# Determine binary names by stripping out the dir names
-BINS       := $(foreach cmd,${COMMANDS},$(notdir ${cmd}))
-
 
 compile-clean:
 	@echo "=== $(PROJECT_NAME) === [ compile-clean    ]: removing binaries..."
@@ -27,22 +24,16 @@ compile: compile-only
 compile-all:
 	@echo "=== $(PROJECT_NAME) === [ compile          ]: building commands:"
 	@mkdir -p $(BUILD_DIR)/$(GOOS)
-	@for b in $(BINS); do \
-		for os in $(COMPILE_OS); do \
-			echo "=== $(PROJECT_NAME) === [ compile          ]:     $(BUILD_DIR)$$os/$$b"; \
-			BUILD_FILES=`find $(SRCDIR)/cmd/$$b -type f -name "*.go"` ; \
-			CGO_ENABLED=0 GOOS=$$os $(GO) build -ldflags=$(LDFLAGS) -o $(BUILD_DIR)/$$os/$$b $$BUILD_FILES ; \
-		done \
+	@for os in $(COMPILE_OS); do \
+		echo "=== $(PROJECT_NAME) === [ compile          ]:     $(BUILD_DIR)/$$os/$(BINARYNAME)"; \
+		CGO_ENABLED=0 GOOS=$$os $(GO) build -ldflags=$(LDFLAGS) -o $(BUILD_DIR)/$$os/$(BINARYNAME) . ; \
 	done
 
 compile-only:
-	@echo "=== $(PROJECT_NAME) === [ compile          ]: building commands:"
+	@echo "=== $(PROJECT_NAME) === [ compile          ]: building commands: $(BINARYNAME)"
 	@mkdir -p $(BUILD_DIR)/$(GOOS)
-	@for b in $(BINS); do \
-		echo "=== $(PROJECT_NAME) === [ compile          ]:     $(BUILD_DIR)/$(GOOS)/$$b"; \
-		BUILD_FILES=`find $(SRCDIR)/cmd/$$b -type f -name "*.go"` ; \
-		CGO_ENABLED=0 GOOS=$(GOOS) $(GO) build -ldflags=$(LDFLAGS) -o $(BUILD_DIR)/$(GOOS)/$$b $$BUILD_FILES ; \
-	done
+	@echo "=== $(PROJECT_NAME) === [ compile          ]:     $(BUILD_DIR)/$(GOOS)/$$BINARYNAME";
+	@CGO_ENABLED=0 GOOS=$(GOOS) $(GO) build -ldflags=$(LDFLAGS) -o $(BUILD_DIR)/$(GOOS)/$(BINARYNAME) . ; \
 
 # Override GOOS for these specific targets
 compile-darwin: GOOS=darwin


### PR DESCRIPTION
This addresses something overlooked in the prior PR where the compile step was happily creating no binaries and not throwing an error and wasn't caught until the build system attempted to create a new docker image but no binary was present. 