### PR TITLE
chore: update goreleaser for local directory binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ before:
 builds:
   -
     id: newrelic
-    dir: cmd/manager
+    dir: .
     binary: manager
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
Updates goreleaser to use a binary from the root directory as needed by kubebuilder