### PR TITLE
fix: update manager namespace created

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: system
+  name: newrelic-kubernetes-operator-system
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
The current instructions / default config create a "system" namespace, and then fail to add the operator to "newrelic-kubernetes-operator-system" namespace.  This adds the correct namespace.