### PR TITLE
chore: surface errors, requeue, refactor

### DIFF
--- a/controllers/alerts_policy_controller.go
+++ b/controllers/alerts_policy_controller.go
@@ -19,11 +19,11 @@ import (
 	"context"
 	"errors"
 	"reflect"
-	"strings"
 
 	newrelic "github.com/newrelic/go-agent/v3/newrelic"
 	"github.com/newrelic/newrelic-client-go/pkg/alerts"
 	v1 "k8s.io/api/core/v1"
+	kErr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-logr/logr"
@@ -65,18 +65,20 @@ func (r *AlertsPolicyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	var policy nrv1.AlertsPolicy
 	err := r.Client.Get(r.ctx, req.NamespacedName, &policy)
 	if err != nil {
-		if strings.Contains(err.Error(), " not found") {
+		if kErr.IsNotFound(err) {
 			r.Log.Info("AlertsPolicy 'not found' after being deleted. This is expected and no cause for alarm", "error", err)
 			return ctrl.Result{}, nil
 		}
-
 		r.Log.Error(err, "Failed to GET policy", "name", req.NamespacedName.String())
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 	r.Log.Info("Starting reconcile action")
 	r.Log.Info("policy", "policy.Spec.Condition", policy.Spec.Conditions, "policy.status.applied.conditions", policy.Status.AppliedSpec.Conditions)
 
-	r.apiKey = r.getAPIKeyOrSecret(policy)
+	r.apiKey, err = r.getAPIKeyOrSecret(policy)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	if r.apiKey == "" {
 		return ctrl.Result{}, errors.New("api key is blank")
@@ -622,10 +624,10 @@ func (r *AlertsPolicyReconciler) deleteNewRelicAlertPolicy(policy *nrv1.AlertsPo
 	return nil
 }
 
-func (r *AlertsPolicyReconciler) getAPIKeyOrSecret(policy nrv1.AlertsPolicy) string {
+func (r *AlertsPolicyReconciler) getAPIKeyOrSecret(policy nrv1.AlertsPolicy) (string, error) {
 	defer r.txn.StartSegment("getAPIKeyOrSecret").End()
 	if policy.Spec.APIKey != "" {
-		return policy.Spec.APIKey
+		return policy.Spec.APIKey, nil
 	}
 
 	if policy.Spec.APIKeySecret != (nrv1.NewRelicAPIKeySecret{}) {
@@ -634,12 +636,11 @@ func (r *AlertsPolicyReconciler) getAPIKeyOrSecret(policy nrv1.AlertsPolicy) str
 		getErr := r.Client.Get(context.Background(), key, &apiKeySecret)
 		if getErr != nil {
 			r.Log.Error(getErr, "Failed to retrieve secret", "secret", apiKeySecret)
-
-			return ""
+			return "", getErr
 		}
 
-		return string(apiKeySecret.Data[policy.Spec.APIKeySecret.KeyName])
+		return string(apiKeySecret.Data[policy.Spec.APIKeySecret.KeyName]), nil
 	}
 
-	return ""
+	return "", nil
 }

--- a/controllers/apmalertcondition_controller.go
+++ b/controllers/apmalertcondition_controller.go
@@ -19,9 +19,9 @@ import (
 	"context"
 	"errors"
 	"reflect"
-	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	kErr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-logr/logr"
@@ -61,15 +61,18 @@ func (r *ApmAlertConditionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, 
 	var condition nralertsv1.ApmAlertCondition
 	err := r.Client.Get(ctx, req.NamespacedName, &condition)
 	if err != nil {
-		if strings.Contains(err.Error(), " not found") {
+		if kErr.IsNotFound(err) {
 			r.Log.Info("Expected error 'not found' after condition deleted", "error", err)
 			return ctrl.Result{}, nil
 		}
 		r.Log.Error(err, "Tried getting condition", "name", req.NamespacedName.String())
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
-	r.apiKey = r.getAPIKeyOrSecret(condition)
+	r.apiKey, err = r.getAPIKeyOrSecret(condition)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	if r.apiKey == "" {
 		return ctrl.Result{}, errors.New("api key is blank")
@@ -146,42 +149,7 @@ func (r *ApmAlertConditionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, 
 	//check if condition has condition id
 	r.checkForExistingCondition(&condition)
 
-	APICondition := condition.Spec.APICondition()
-
-	if condition.Status.ConditionID != 0 && !reflect.DeepEqual(&condition.Spec, condition.Status.AppliedSpec) {
-		r.Log.Info("updating condition", "ConditionName", condition.Name, "API fields", APICondition)
-		APICondition.ID = condition.Status.ConditionID
-		updatedCondition, err := alertsClient.UpdateCondition(APICondition)
-		if err != nil {
-			r.Log.Error(err, "failed to update condition")
-		} else {
-			condition.Status.AppliedSpec = &condition.Spec
-			condition.Status.ConditionID = updatedCondition.ID
-		}
-
-		err = r.Client.Update(ctx, &condition)
-		if err != nil {
-			r.Log.Error(err, "tried updating condition status", "name", req.NamespacedName)
-		}
-	} else {
-		r.Log.Info("Creating condition", "ConditionName", condition.Name, "API fields", APICondition)
-		createdCondition, err := alertsClient.CreateCondition(condition.Spec.ExistingPolicyID, APICondition)
-		if err != nil {
-			r.Log.Error(err, "failed to create condition",
-				"conditionId", condition.Status.ConditionID,
-				"region", condition.Spec.Region,
-				"Api Key", interfaces.PartialAPIKey(r.apiKey),
-			)
-		} else {
-			condition.Status.AppliedSpec = &condition.Spec
-			condition.Status.ConditionID = createdCondition.ID
-		}
-
-		err = r.Client.Update(ctx, &condition)
-		if err != nil {
-			r.Log.Error(err, "tried updating condition status", "name", req.NamespacedName)
-		}
-	}
+	r.writeNewRelicAlertCondition(ctx, req, alertsClient, condition)
 
 	return ctrl.Result{}, nil
 }
@@ -218,6 +186,45 @@ func (r *ApmAlertConditionReconciler) checkForExistingCondition(condition *nrale
 	}
 }
 
+func (r *ApmAlertConditionReconciler) writeNewRelicAlertCondition(ctx context.Context, req ctrl.Request, alertsClient interfaces.NewRelicAlertsClient, condition nralertsv1.ApmAlertCondition) {
+	APICondition := condition.Spec.APICondition()
+
+	if condition.Status.ConditionID != 0 && !reflect.DeepEqual(&condition.Spec, condition.Status.AppliedSpec) {
+		r.Log.Info("updating condition", "ConditionName", condition.Name, "API fields", APICondition)
+		APICondition.ID = condition.Status.ConditionID
+		updatedCondition, err := alertsClient.UpdateCondition(APICondition)
+		if err != nil {
+			r.Log.Error(err, "failed to update condition")
+		} else {
+			condition.Status.AppliedSpec = &condition.Spec
+			condition.Status.ConditionID = updatedCondition.ID
+		}
+
+		err = r.Client.Update(ctx, &condition)
+		if err != nil {
+			r.Log.Error(err, "tried updating condition status", "name", req.NamespacedName)
+		}
+	} else {
+		r.Log.Info("Creating condition", "ConditionName", condition.Name, "API fields", APICondition)
+		createdCondition, err := alertsClient.CreateCondition(condition.Spec.ExistingPolicyID, APICondition)
+		if err != nil {
+			r.Log.Error(err, "failed to create condition",
+				"conditionId", condition.Status.ConditionID,
+				"region", condition.Spec.Region,
+				"Api Key", interfaces.PartialAPIKey(r.apiKey),
+			)
+		} else {
+			condition.Status.AppliedSpec = &condition.Spec
+			condition.Status.ConditionID = createdCondition.ID
+		}
+
+		err = r.Client.Update(ctx, &condition)
+		if err != nil {
+			r.Log.Error(err, "tried updating condition status", "name", req.NamespacedName)
+		}
+	}
+}
+
 func (r *ApmAlertConditionReconciler) deleteNewRelicAlertCondition(condition nralertsv1.ApmAlertCondition) error {
 	defer r.txn.StartSegment("deleteNewRelicAlertCondition").End()
 	r.Log.Info("Deleting condition", "conditionName", condition.Spec.Name)
@@ -234,10 +241,10 @@ func (r *ApmAlertConditionReconciler) deleteNewRelicAlertCondition(condition nra
 	return nil
 }
 
-func (r *ApmAlertConditionReconciler) getAPIKeyOrSecret(condition nralertsv1.ApmAlertCondition) string {
+func (r *ApmAlertConditionReconciler) getAPIKeyOrSecret(condition nralertsv1.ApmAlertCondition) (string, error) {
 	defer r.txn.StartSegment("getAPIKeyOrSecret").End()
 	if condition.Spec.APIKey != "" {
-		return condition.Spec.APIKey
+		return condition.Spec.APIKey, nil
 	}
 
 	if condition.Spec.APIKeySecret != (nralertsv1.NewRelicAPIKeySecret{}) {
@@ -245,11 +252,11 @@ func (r *ApmAlertConditionReconciler) getAPIKeyOrSecret(condition nralertsv1.Apm
 		var apiKeySecret v1.Secret
 		if getErr := r.Client.Get(context.Background(), key, &apiKeySecret); getErr != nil {
 			r.Log.Error(getErr, "Error retrieving secret", "secret", apiKeySecret)
-			return ""
+			return "", getErr
 		}
 
-		return string(apiKeySecret.Data[condition.Spec.APIKeySecret.KeyName])
+		return string(apiKeySecret.Data[condition.Spec.APIKeySecret.KeyName]), nil
 	}
 
-	return ""
+	return "", nil
 }

--- a/controllers/policy_controller.go
+++ b/controllers/policy_controller.go
@@ -19,11 +19,11 @@ import (
 	"context"
 	"errors"
 	"reflect"
-	"strings"
 
 	newrelic "github.com/newrelic/go-agent/v3/newrelic"
 	"github.com/newrelic/newrelic-client-go/pkg/alerts"
 	v1 "k8s.io/api/core/v1"
+	kErr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-logr/logr"
@@ -62,17 +62,20 @@ func (r *PolicyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	var policy nrv1.Policy
 	err := r.Client.Get(r.ctx, req.NamespacedName, &policy)
 	if err != nil {
-		if strings.Contains(err.Error(), " not found") {
+		if kErr.IsNotFound(err) {
 			r.Log.Info("Policy 'not found' after being deleted. This is expected and no cause for alarm", "error", err)
 			return ctrl.Result{}, nil
 		}
 		r.Log.Error(err, "Failed to GET policy", "name", req.NamespacedName.String())
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 	r.Log.Info("Starting reconcile action")
 	r.Log.Info("policy", "policy.Spec.Condition", policy.Spec.Conditions, "policy.status.applied.conditions", policy.Status.AppliedSpec.Conditions)
 
-	r.apiKey = r.getAPIKeyOrSecret(policy)
+	r.apiKey, err = r.getAPIKeyOrSecret(policy)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	if r.apiKey == "" {
 		return ctrl.Result{}, errors.New("api key is blank")
@@ -608,10 +611,10 @@ func (r *PolicyReconciler) deleteNewRelicAlertPolicy(policy *nrv1.Policy) error 
 	return nil
 }
 
-func (r *PolicyReconciler) getAPIKeyOrSecret(policy nrv1.Policy) string {
+func (r *PolicyReconciler) getAPIKeyOrSecret(policy nrv1.Policy) (string, error) {
 	defer r.txn.StartSegment("getAPIKeyOrSecret").End()
 	if policy.Spec.APIKey != "" {
-		return policy.Spec.APIKey
+		return policy.Spec.APIKey, nil
 	}
 
 	if policy.Spec.APIKeySecret != (nrv1.NewRelicAPIKeySecret{}) {
@@ -620,11 +623,11 @@ func (r *PolicyReconciler) getAPIKeyOrSecret(policy nrv1.Policy) string {
 		getErr := r.Client.Get(context.Background(), key, &apiKeySecret)
 		if getErr != nil {
 			r.Log.Error(getErr, "Failed to retrieve secret", "secret", apiKeySecret)
-			return ""
+			return "", getErr
 		}
 
-		return string(apiKeySecret.Data[policy.Spec.APIKeySecret.KeyName])
+		return string(apiKeySecret.Data[policy.Spec.APIKeySecret.KeyName]), nil
 	}
 
-	return ""
+	return "", nil
 }


### PR DESCRIPTION
The initial idea in this PR was to surface the underlying errors that happen when `r.Client.Get()`ing an object from the API which is not found. So i.e. if we try to get a non-existing `Secret` we'll now get the actual error instead of a misleading `api key is blank` error.

Additionally, all `Reconcile()` functions now return `ctrl.Request{}, err` when a `r.Client.Get()` error occurs, thus making use of the retry mechanism which is [built-in into the controller](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/internal/controller/controller.go#L263-L281).

However, some of the strict pre-commit hooks started not passing because of a cyclomatic complexity of 21 in some `Reconcile()` functions, so I ultimately refactored a bunch of them. I basically moved the resource creation/update part out of `Reconcile()` and into a new `writeNewRelicAlertCondition()` function.
