### PR TITLE
feat: add parent kubernetes object references

### DIFF
--- a/controllers/alerts_policy_controller.go
+++ b/controllers/alerts_policy_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +40,8 @@ import (
 const (
 	alertsPolicyDeleteFinalizer = "policies.finalizers.nr.k8s.newrelic.com"
 )
+
+var trueVar = true
 
 // AlertsPolicyReconciler reconciles a AlertsPolicy object
 type AlertsPolicyReconciler struct {
@@ -366,6 +369,17 @@ func (r *AlertsPolicyReconciler) createOrUpdateConditions(policy *nrv1.AlertsPol
 	return nil
 }
 
+func asOwner(p *nrv1.AlertsPolicy) metav1.OwnerReference {
+
+	return metav1.OwnerReference{
+		APIVersion: "v1", //this probablby shouldn't be hardcoded this way but doesn't work in tests for some reason
+		Kind:       "AlertsPolicy",
+		Name:       p.Name,
+		UID:        p.UID,
+		Controller: &trueVar,
+	}
+}
+
 func (r *AlertsPolicyReconciler) createNrqlCondition(policy *nrv1.AlertsPolicy, condition *nrv1.AlertsPolicyCondition) error {
 	defer r.txn.StartSegment("createNrqlCondition").End()
 	var alertsNrqlCondition nrv1.AlertsNrqlCondition
@@ -379,6 +393,7 @@ func (r *AlertsPolicyReconciler) createNrqlCondition(policy *nrv1.AlertsPolicy, 
 	alertsNrqlCondition.Spec.APIKeySecret = policy.Spec.APIKeySecret
 	alertsNrqlCondition.Spec.AccountID = policy.Spec.AccountID
 	alertsNrqlCondition.Status.AppliedSpec = &nrv1.AlertsNrqlConditionSpec{}
+	alertsNrqlCondition.OwnerReferences = append(alertsNrqlCondition.OwnerReferences, asOwner(policy))
 
 	r.Log.Info("creating condition", "condition", condition.Name, "conditionName", condition.Spec.Name, "alertsNrqlCondition", alertsNrqlCondition)
 
@@ -411,6 +426,7 @@ func (r *AlertsPolicyReconciler) createApmCondition(policy *nrv1.AlertsPolicy, c
 	apmCondition.Status.AppliedSpec = &nrv1.AlertsAPMConditionSpec{}
 
 	apmCondition.Spec.ExistingPolicyID = policy.Status.PolicyID
+	apmCondition.OwnerReferences = append(apmCondition.OwnerReferences, asOwner(policy))
 
 	r.Log.Info("creating apm condition", "condition", condition.Name, "conditionName", condition.Spec.Name, "alertsAPMCondition", apmCondition)
 	errCondition := r.Create(r.ctx, &apmCondition)

--- a/controllers/alerts_policy_controller.go
+++ b/controllers/alerts_policy_controller.go
@@ -372,7 +372,7 @@ func (r *AlertsPolicyReconciler) createOrUpdateConditions(policy *nrv1.AlertsPol
 func asOwner(p *nrv1.AlertsPolicy) metav1.OwnerReference {
 
 	return metav1.OwnerReference{
-		APIVersion: "v1", //this probablby shouldn't be hardcoded this way but doesn't work in tests for some reason
+		APIVersion: nrv1.GroupVersion.String(),
 		Kind:       "AlertsPolicy",
 		Name:       p.Name,
 		UID:        p.UID,

--- a/controllers/alerts_policy_controller_integration_test.go
+++ b/controllers/alerts_policy_controller_integration_test.go
@@ -229,9 +229,6 @@ var _ = Describe("alertspolicy reconciliation", func() {
 					Namespace: endStateAlertsPolicy.Spec.Conditions[0].Namespace,
 				}
 				err = k8sClient.Get(ctx, conditionNameType, &endStateCondition)
-				// expectedOwner := []v1.OwnerReference{
-				//      {}
-				// }
 
 				Expect(endStateCondition.ObjectMeta.OwnerReferences[0].Name).To(Equal(endStateAlertsPolicy.Name))
 			})


### PR DESCRIPTION
This adds owner resource annotations for policy created apm and NRQL AlertsCondition objects. 

![Screen Shot 2020-10-15 at 9 53 49 AM](https://user-images.githubusercontent.com/7946679/96161721-7a208180-0ecc-11eb-9879-fe55173739ae.png)
