### PR TITLE
fix: namespace's prefix deleted.

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: newrelic-kubernetes-operator-system
+  name: system
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Namespace prefix "newrelic-kubernetes-operator-" is not needed because of defined by kustomization.yaml