### PR TITLE
fix: namespace's prefix deleted(manager.yaml)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: newrelic-kubernetes-operator-system
+  name: system
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
fix: namespace's prefix deleted(manager.yaml)