### PR TITLE
chore(docs): Update README to add differentiation with newrelic-k8s-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Currently the operator supports managing the following resources:
 - Alert Conditions for APM, Browser and mobile
 - Alert Channels
 
+If you are looking for New Relic's Kubernetes operator for managing New Relic's Kubernetes integration, please see [newrelic-k8s-operator](https://github.com/newrelic/newrelic-k8s-operator). 
 
 # Quick Start
 > <small>**Note:** These quick start instructions do **not** require you to clone the repo.</small>


### PR DESCRIPTION
We recently added newrelic-k8s-operator which is an operator for managing New Relic's Kubernetes integration. This updates the README to direct users to the right place if that is what they were looking for.